### PR TITLE
Refactor and fix perf regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ A C++14/C++17 header-only library for simple, efficient, and robust serializatio
     * ~1800 lines of high-level, straightforward, generously spaced code including whitespace/comments
     * C++20 Module ready (does not leak preprocessor defines/macros beyond its own file)
 
-* Fast and efficient processing
-    * See Performance section below
+* Fast, Efficient, and Safe processing
+    * [Safety and Robustness](#Safety-and-Robustness)
+    * [Performance](#Performance)
+
 
 ## Usage and Integration
 
@@ -31,6 +33,8 @@ A C++14/C++17 header-only library for simple, efficient, and robust serializatio
 * [nlohmann::json](https://github.com/nlohmann/json) (must be referenceable using `#include <nlohmann/json.hpp`)
 
 ### Code
+
+Example: General usage
 
 ```C++
 // Single header...
@@ -50,21 +54,39 @@ helmet.buffers.back().SetAsEmbeddedResource();
 fx::gltf::Save(helment, "NewHelmet.glb", false);
 ```
 
+Example: Placing a quota on how large files and buffers can be; e.g. when loading files from potentially hostile sources
+
+```C++
+#include <fx/gltf.h>
+
+// Create an 8mb quota for binary file sizes as well as any external buffer contained inside...
+// [Default is 32mb for each]
+fx::gltf::ReadQuotas readQuotas{};
+readQuotas.MaxFileSize = 8 * 1024 * 1024;
+readQuotas.MaxBufferByteLength = 8 * 1024 * 1024;
+
+fx::gltf::Document docFromInternet = fx::gltf::LoadFromBinary("untrusted.glb", readQuotas);
+
+```
+
 ## Safety and Robustness
 
-* Automated, roundtrip testing for all models inside [glTF-Sample-Models](https://github.com/KhronosGroup/glTF-Sample-Models)
+* Robust automated testing
 
-| Model Type  | Status |
-| ------------| ------ |
+    * Roundtrip testing for all models inside [glTF-Sample-Models](https://github.com/KhronosGroup/glTF-Sample-Models)
+    * Extensive testing of Base64 encoding and decoding
+    * Strict required vs. optional element loading and saving
+
+| Model Type  | Status: glTF-Sample-Models |
+| ------------| -------------------------- |
 | .gltf files w/external resources  | 100% complete and passing  |
 | .gltf files w/embedded resources  | 100% complete and passing (2 models excluded due to out-of-spec mimetypes)  |
 | .gltf files w/pbrSpecularGlossiness extension | 100% complete and passing  |
 | .glb files                        | 100% complete and passing  |
 
-
-* Built-in protection against directory traversal when loading external resource URIs from malicious .gltf files
-* Extensive testing of Base64 encoding and decoding
-* Strict required vs. optional element loading and saving
+* Safety
+    * Built-in protection against directory traversal when loading external resource URIs from malicious files
+    * Enforced quotas on maximum files sizes and buffers to prevent DOS's from malicious files
 
 * Developed using both clang-tidy and MSVC CppCoreCheck toolsets
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,7 @@ A C++14/C++17 header-only library for simple, efficient, and robust serializatio
 ### Installation
 * [`gltf.h`](https://github.com/jessey-git/fx-gltf/blob/master/include/fx/gltf.h) is the single required file available in the `include/fx` repo path.
 
-A typical installation will preserve the directory hierarchy: ```#include <fx/gltf.h>```
-
-Planned: publishing to [vcpkg](https://github.com/Microsoft/vcpkg) for even easier installs within MSVC environments
+  A typical installation will preserve the directory hierarchy: ```#include <fx/gltf.h>```
 
 ### Dependencies
 * [nlohmann::json](https://github.com/nlohmann/json) (must be referenceable using `#include <nlohmann/json.hpp`)
@@ -216,6 +214,9 @@ Planned: Ship a C++20 Modules file in addition to the header
 
 ### API
 * No known issues
+
+### Packaging
+ * Publish to [vcpkg](https://github.com/Microsoft/vcpkg) for easier package maintenance within MSVC environments
 
 ### General (future)
 * API: Improvement: Make creation of objects easier when building documents by hand (C++20 will allow aggregate struct initialization so maybe that's all that is needed...)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ helmet.buffers.back().data = ...;
 helmet.buffers.back().SetAsEmbeddedResource();
 
 // Saving back as text...
-helmet.Save("NewHelmet.glb", false);
+fx::gltf::Save(helment, "NewHelmet.glb", false);
 ```
 
 ## Safety and Robustness

--- a/include/fx/gltf.h
+++ b/include/fx/gltf.h
@@ -1754,7 +1754,7 @@ namespace gltf
         detail::WriteExtensions(json, document.extensionsAndExtras);
     }
 
-    inline Document LoadFromText(std::string const & documentFilePath, ReadQuotas const & readQuota = {})
+    inline Document LoadFromText(std::string const & documentFilePath, ReadQuotas const & readQuotas = {})
     {
         nlohmann::json json;
         {
@@ -1767,10 +1767,10 @@ namespace gltf
             file >> json;
         }
 
-        return detail::Create(json, { detail::GetDocumentRootPath(documentFilePath), readQuota });
+        return detail::Create(json, { detail::GetDocumentRootPath(documentFilePath), readQuotas });
     }
 
-    inline Document LoadFromBinary(std::string const & documentFilePath, ReadQuotas const & readQuota = {})
+    inline Document LoadFromBinary(std::string const & documentFilePath, ReadQuotas const & readQuotas = {})
     {
         std::vector<uint8_t> binary{};
         {
@@ -1786,9 +1786,9 @@ namespace gltf
                 throw invalid_gltf_document("Invalid GLB file");
             }
 
-            if (fileSize > readQuota.MaxFileSize)
+            if (fileSize > readQuotas.MaxFileSize)
             {
-                throw invalid_gltf_document("Invalid GLB file", "file size > readQuota.MaxFileSize");
+                throw invalid_gltf_document("Invalid GLB file", "file size > readQuotas.MaxFileSize");
             }
 
             binary.resize(fileSize);
@@ -1806,7 +1806,7 @@ namespace gltf
 
         return detail::Create(
             nlohmann::json::parse({ &binary[detail::HeaderSize], header.jsonHeader.chunkLength }),
-            { detail::GetDocumentRootPath(documentFilePath), readQuota, &binary, header.jsonHeader.chunkLength + detail::HeaderSize });
+            { detail::GetDocumentRootPath(documentFilePath), readQuotas, &binary, header.jsonHeader.chunkLength + detail::HeaderSize });
     }
 
     inline void Save(Document const & document, std::string documentFilePath, bool useBinaryFormat)

--- a/test/src/unit-exceptions.cpp
+++ b/test/src/unit-exceptions.cpp
@@ -116,6 +116,19 @@ TEST_CASE("exceptions")
         Mutate(json, [](nlohmann::json & m) { m["materials"][0]["alphaMode"] = "opaque"; }, "material.alphaMode");
     }
 
+    SECTION("load : quotas")
+    {
+        std::string externalFile{ "data/glTF-Sample-Models/2.0/Box/glTF/Box.gltf" };
+        std::string glbFile{ "data/glTF-Sample-Models/2.0/Box/glTF-Binary/Box.glb" };
+
+        fx::gltf::ReadQuotas readQuotas{};
+        readQuotas.MaxBufferByteLength = 500;
+        REQUIRE_THROWS_MATCHES(fx::gltf::LoadFromText(externalFile, readQuotas), fx::gltf::invalid_gltf_document, ExceptionContainsMatcher("MaxBufferByteLength"));
+
+        readQuotas.MaxFileSize = 500;
+        REQUIRE_THROWS_MATCHES(fx::gltf::LoadFromBinary(externalFile, readQuotas), fx::gltf::invalid_gltf_document, ExceptionContainsMatcher("MaxFileSize"));
+    }
+
     SECTION("save : invalid buffers")
     {
         fx::gltf::Document doc;

--- a/test/src/unit-exceptions.cpp
+++ b/test/src/unit-exceptions.cpp
@@ -8,6 +8,8 @@
 #include <fx/gltf.h>
 #include <nlohmann/json.hpp>
 
+#include "utility.h"
+
 // The matcher class
 class ExceptionContainsMatcher : public Catch::MatcherBase<std::exception>
 {
@@ -16,7 +18,7 @@ public:
 
     virtual bool match(std::exception const & e) const override
     {
-        message_.assign(e.what());
+        utility::FormatException(message_, e);
         return message_.find(text_) != std::string::npos;
     }
 
@@ -39,8 +41,7 @@ void Mutate(nlohmann::json const & incoming, TMutator && mutator, std::string co
     INFO("Expecting exception containing : " << text);
     INFO("Mutated json : " << mutated.dump(2));
 
-    fx::gltf::Document doc;
-    REQUIRE_THROWS_MATCHES(doc = mutated, fx::gltf::invalid_gltf_document, ExceptionContainsMatcher(text));
+    REQUIRE_THROWS_MATCHES(fx::gltf::detail::Create(mutated, {}), fx::gltf::invalid_gltf_document, ExceptionContainsMatcher(text));
 }
 
 TEST_CASE("exceptions")
@@ -57,7 +58,7 @@ TEST_CASE("exceptions")
                   "samplers": [ { "input": 6, "interpolation": "LINEAR", "output": 7 } ]
               } ],
               "asset": { "version": "2.0" },
-              "buffers": [ { "byteLength": 10 } ],
+              "buffers": [ { "byteLength": 10, "uri": "data:application/octet-stream;base64,AAAABB==" } ],
               "bufferViews": [ { "buffer": 0, "byteLength": 10 } ],
               "cameras": [ { "perspective": { "yfov": 0.6, "znear": 1.0 }, "type": "perspective" } ],
               "materials": [ { "alphaMode": "OPAQUE", "pbrMetallicRoughness": { "baseColorTexture": { "index": 0 }, "metallicRoughnessTexture": { "index": 1 } }, "normalTexture": { "index": 2 }, "occlusionTexture": { "index": 1 }, "emissiveTexture": { "index": 3 } } ],
@@ -108,6 +109,9 @@ TEST_CASE("exceptions")
     {
         Mutate(json, [](nlohmann::json & m) { m["accessors"][0]["type"] = "vec3"; }, "accessor.type");
         Mutate(json, [](nlohmann::json & m) { m["animations"][0]["samplers"][0]["interpolation"] = "linear"; }, "animation.sampler.interpolation");
+        Mutate(json, [](nlohmann::json & m) { m["buffers"][0]["byteLength"] = 0; }, "buffer.byteLength");
+        Mutate(json, [](nlohmann::json & m) { m["buffers"][0]["uri"] = "../dir/traversal.bin"; }, "buffer.uri");
+        Mutate(json, [](nlohmann::json & m) { m["buffers"][0]["uri"] = "nonexistant.bin"; }, "buffer.uri");
         Mutate(json, [](nlohmann::json & m) { m["cameras"][0]["type"] = "D-SLR"; }, "camera.type");
         Mutate(json, [](nlohmann::json & m) { m["materials"][0]["alphaMode"] = "opaque"; }, "material.alphaMode");
     }

--- a/test/src/unit-exceptions.cpp
+++ b/test/src/unit-exceptions.cpp
@@ -119,18 +119,18 @@ TEST_CASE("exceptions")
         INFO("No buffers");
         doc = json;
         doc.buffers.clear();
-        REQUIRE_THROWS_AS(doc.Save("nop", false), fx::gltf::invalid_gltf_document);
+        REQUIRE_THROWS_AS(fx::gltf::Save(doc, "nop", false), fx::gltf::invalid_gltf_document);
 
         INFO("Buffer byteLength = 0");
         doc = json;
         doc.buffers[0].byteLength = 0;
-        REQUIRE_THROWS_AS(doc.Save("nop", false), fx::gltf::invalid_gltf_document);
+        REQUIRE_THROWS_AS(fx::gltf::Save(doc, "nop", false), fx::gltf::invalid_gltf_document);
 
         INFO("Buffer byteLength != data size");
         doc = json;
         doc.buffers[0].byteLength = 20;
         doc.buffers[0].data.resize(10);
-        REQUIRE_THROWS_AS(doc.Save("nop", false), fx::gltf::invalid_gltf_document);
+        REQUIRE_THROWS_AS(fx::gltf::Save(doc, "nop", false), fx::gltf::invalid_gltf_document);
 
         INFO("A second buffer with empty uri");
         doc = json;
@@ -141,13 +141,13 @@ TEST_CASE("exceptions")
         doc.buffers[1].uri.clear();
         doc.buffers[1].byteLength = 20;
         doc.buffers[1].data.resize(20);
-        REQUIRE_THROWS_AS(doc.Save("nop", false), fx::gltf::invalid_gltf_document);
+        REQUIRE_THROWS_AS(fx::gltf::Save(doc, "nop", false), fx::gltf::invalid_gltf_document);
 
         INFO("Binary save with invalid buffer uri");
         doc = json;
         doc.buffers[0].uri = "not empty";
         doc.buffers[0].byteLength = 20;
         doc.buffers[0].data.resize(20);
-        REQUIRE_THROWS_AS(doc.Save("nop", true), fx::gltf::invalid_gltf_document);
+        REQUIRE_THROWS_AS(fx::gltf::Save(doc, "nop", true), fx::gltf::invalid_gltf_document);
     }
 }

--- a/test/src/unit-saveload.cpp
+++ b/test/src/unit-saveload.cpp
@@ -25,7 +25,7 @@ TEST_CASE("saveload")
         std::string originalUri = originalDocument.buffers.front().uri;
 
         originalDocument.buffers.front().SetEmbeddedResource();
-        originalDocument.Save(newFile, false);
+        fx::gltf::Save(originalDocument, newFile, false);
 
         fx::gltf::Document newDocument = fx::gltf::LoadFromText(newFile);
 
@@ -42,7 +42,7 @@ TEST_CASE("saveload")
         fx::gltf::Document originalDocument = fx::gltf::LoadFromText(originalFile);
 
         originalDocument.buffers.front().uri.clear();
-        originalDocument.Save(newFile, true);
+        fx::gltf::Save(originalDocument, newFile, true);
 
         fx::gltf::Document newDocument = fx::gltf::LoadFromBinary(newFile);
 
@@ -59,7 +59,7 @@ TEST_CASE("saveload")
         std::string originalUri = originalDocument.buffers.front().uri;
 
         originalDocument.buffers.front().uri = "test3.bin";
-        originalDocument.Save(newFile, false);
+        fx::gltf::Save(originalDocument, newFile, false);
 
         fx::gltf::Document newDocument = fx::gltf::LoadFromText(newFile);
 
@@ -76,7 +76,7 @@ TEST_CASE("saveload")
         fx::gltf::Document originalDocument = fx::gltf::LoadFromText(originalFile);
 
         originalDocument.buffers.front().uri.clear();
-        originalDocument.Save(newFile, true);
+        fx::gltf::Save(originalDocument, newFile, true);
 
         fx::gltf::Document newDocument = fx::gltf::LoadFromBinary(newFile);
 
@@ -92,7 +92,7 @@ TEST_CASE("saveload")
         fx::gltf::Document originalDocument = fx::gltf::LoadFromBinary(originalFile);
 
         originalDocument.buffers.front().uri = "test5.bin";
-        originalDocument.Save(newFile, false);
+        fx::gltf::Save(originalDocument, newFile, false);
 
         fx::gltf::Document newDocument = fx::gltf::LoadFromText(newFile);
 
@@ -108,7 +108,7 @@ TEST_CASE("saveload")
         fx::gltf::Document originalDocument = fx::gltf::LoadFromBinary(originalFile);
 
         originalDocument.buffers.front().SetEmbeddedResource();
-        originalDocument.Save(newFile, false);
+        fx::gltf::Save(originalDocument, newFile, false);
 
         fx::gltf::Document newDocument = fx::gltf::LoadFromText(newFile);
 
@@ -129,7 +129,7 @@ TEST_CASE("saveload")
         originalDocument.buffers.back().byteLength = static_cast<uint32_t>(newBytes.size());
         originalDocument.buffers.back().data = newBytes;
 
-        originalDocument.Save(newFile, true);
+        fx::gltf::Save(originalDocument, newFile, true);
 
         fx::gltf::Document newDocument = fx::gltf::LoadFromBinary(newFile);
 
@@ -151,7 +151,7 @@ TEST_CASE("saveload")
         originalDocument.buffers.back().data = newBytes;
         originalDocument.buffers.back().SetEmbeddedResource();
 
-        originalDocument.Save(newFile, true);
+        fx::gltf::Save(originalDocument, newFile, true);
 
         fx::gltf::Document newDocument = fx::gltf::LoadFromBinary(newFile);
 

--- a/test/src/utility.cpp
+++ b/test/src/utility.cpp
@@ -20,14 +20,14 @@ namespace utility
 {
     void FormatException(std::string & output, std::exception const & e, int level)
     {
-        output.append(std::string(level, ' ')).append("exception: ").append(e.what()).append("\n");
+        output.append(std::string(level, ' ')).append(e.what()).append("\n");
         try
         {
             std::rethrow_if_nested(e);
         }
         catch (std::exception const & e)
         {
-            FormatException(output, e, level + 1);
+            FormatException(output, e, level + 2);
         }
     }
 


### PR DESCRIPTION
- Refactor a bit to keep the Document type as just data; prevents users from getting confused on what those methods/types were used for. Also offers API symmetry to Load

- Add ability for the user to put a quota on the size of buffers and files that will be loaded into memory (default 32mb each)

- Fix perf regression that occurred when switching to using std::*stream<uint8_t>

- Add more tests and update docs