### PR TITLE
Fixed GLB header chunk length must be 4-byte aligned

### DIFF
--- a/include/fx/gltf.h
+++ b/include/fx/gltf.h
@@ -965,11 +965,12 @@ namespace gltf
                 std::string jsonText = json.dump();
 
                 Buffer const & binBuffer = document.buffers.front();
-                const uint32_t paddedLength = ((binBuffer.byteLength + 3) & (~3u));
-                const uint32_t padding = paddedLength - binBuffer.byteLength;
-                binHeader.chunkLength = paddedLength;
+                const uint32_t binPaddedLength = ((binBuffer.byteLength + 3) & (~3u));
+                const uint32_t binPadding = binPaddedLength - binBuffer.byteLength;
+                binHeader.chunkLength = binPaddedLength;
 
-                header.jsonHeader.chunkLength = jsonText.length() & 0xffffffffu;
+                header.jsonHeader.chunkLength = ((jsonText.length() + 3) & (~3u));
+                const uint32_t headerPadding = (uint32_t)(header.jsonHeader.chunkLength-jsonText.length());
                 header.length = detail::HeaderSize + header.jsonHeader.chunkLength + detail::ChunkHeaderSize + binHeader.chunkLength;
 
                 std::ofstream fileData(documentFilePath, std::ios::binary);
@@ -978,12 +979,14 @@ namespace gltf
                     throw std::system_error(std::make_error_code(std::errc::io_error));
                 }
 
-                const char empty[3] = {};
                 fileData.write(reinterpret_cast<char *>(&header), detail::HeaderSize);
                 fileData.write(jsonText.c_str(), jsonText.length());
+                const char spaces[3] = {' ', ' ', ' '};
+                fileData.write(spaces, headerPadding );
                 fileData.write(reinterpret_cast<char *>(&binHeader), detail::ChunkHeaderSize);
                 fileData.write(reinterpret_cast<char const *>(&binBuffer.data[0]), binBuffer.byteLength);
-                fileData.write(&empty[0], padding);
+                const char nulls[3] = {0,0,0};
+                fileData.write(&nulls[0], binPadding);
 
                 externalBufferIndex = 1;
             }

--- a/include/fx/gltf.h
+++ b/include/fx/gltf.h
@@ -970,7 +970,7 @@ namespace gltf
                 binHeader.chunkLength = binPaddedLength;
 
                 header.jsonHeader.chunkLength = ((jsonText.length() + 3) & (~3u));
-                const uint32_t headerPadding = (uint32_t)(header.jsonHeader.chunkLength-jsonText.length());
+                const uint32_t headerPadding = static_cast<uint32_t>(header.jsonHeader.chunkLength-jsonText.length());
                 header.length = detail::HeaderSize + header.jsonHeader.chunkLength + detail::ChunkHeaderSize + binHeader.chunkLength;
 
                 std::ofstream fileData(documentFilePath, std::ios::binary);
@@ -979,13 +979,14 @@ namespace gltf
                     throw std::system_error(std::make_error_code(std::errc::io_error));
                 }
 
+                const char spaces[3] = { ' ', ' ', ' ' };
+                const char nulls[3] = { 0, 0, 0 };
+
                 fileData.write(reinterpret_cast<char *>(&header), detail::HeaderSize);
                 fileData.write(jsonText.c_str(), jsonText.length());
-                const char spaces[3] = {' ', ' ', ' '};
-                fileData.write(spaces, headerPadding );
+                fileData.write(&spaces[0], headerPadding );
                 fileData.write(reinterpret_cast<char *>(&binHeader), detail::ChunkHeaderSize);
                 fileData.write(reinterpret_cast<char const *>(&binBuffer.data[0]), binBuffer.byteLength);
-                const char nulls[3] = {0,0,0};
                 fileData.write(&nulls[0], binPadding);
 
                 externalBufferIndex = 1;


### PR DESCRIPTION
I was testing creation of GLB files, and found the [glTF Validator](https://github.khronos.org/glTF-Validator/) would trip over the built GLB binary.   Needed to align the JSON header chunk to a 4-byte boundary.

Also cleaned up some naming to make it clearer which padding we're talking about.
- JSON padding must be spaces (%20)
- BIN padding must be null chars (%0)

Super library, thanks!