### PR TITLE
Provide loading and saving functions that use STL streams + preserve extra binary chunks per glTF 2.0 spec

### DIFF
--- a/include/fx/gltf.h
+++ b/include/fx/gltf.h
@@ -1807,10 +1807,6 @@ namespace gltf
         inline void Save(Document const & document, std::string const & documentFilePath, bool useBinaryFormat)
         {
             std::ofstream file(documentFilePath, std::ios::binary);
-            if (!file.good())
-            {
-                throw std::system_error(std::make_error_code(std::errc::io_error));
-            }
             SaveToStream(document, file, detail::GetDocumentRootPath(documentFilePath), useBinaryFormat);
         }
     } // namespace detail
@@ -1867,6 +1863,10 @@ namespace gltf
             std::vector<uint8_t> binary(detail::HeaderSize);
             detail::GLBHeader header;
             {
+                if (!is.good())
+                {
+                    throw std::system_error(std::make_error_code(std::errc::io_error));
+                }
                 is.read(reinterpret_cast<char *>(&binary[0]), detail::HeaderSize);
                 if (!is.good())
                 {
@@ -1935,23 +1935,8 @@ namespace gltf
 
     inline Document LoadFromBinary(std::string const & documentFilePath, ReadQuotas const & readQuotas = {})
     {
-        try
-        {
-            std::ifstream file(documentFilePath, std::ios::binary);
-            if (!file.is_open())
-            {
-                throw std::system_error(std::make_error_code(std::errc::no_such_file_or_directory));
-            }
-            return LoadFromBinaryStream(file, detail::GetDocumentRootPath(documentFilePath), readQuotas);
-        }
-        catch (std::system_error &)
-        {
-            throw;
-        }
-        catch (...)
-        {
-            std::throw_with_nested(invalid_gltf_document("Invalid glTF document. See nested exception for details."));
-        }
+        std::ifstream file(documentFilePath, std::ios::binary);
+        return LoadFromBinaryStream(file, detail::GetDocumentRootPath(documentFilePath), readQuotas);
     }
 
     inline void SaveToStream(Document const & document, std::ostream & os, std::string const & bufferRootPath, bool useBinaryFormat)

--- a/test/src/unit-exceptions.cpp
+++ b/test/src/unit-exceptions.cpp
@@ -141,10 +141,10 @@ TEST_CASE("exceptions")
 
         fx::gltf::ReadQuotas readQuotas{};
         readQuotas.MaxBufferByteLength = 500;
-        REQUIRE_THROWS_MATCHES(fx::gltf::LoadFromText(externalFile, readQuotas), fx::gltf::invalid_gltf_document, ExceptionContainsMatcher("MaxBufferByteLength"));
+        REQUIRE_THROWS_MATCHES(fx::gltf::LoadFromText(externalFile, readQuotas), fx::gltf::invalid_gltf_document, ExceptionContainsMatcher("MaxBufferByteLength", true));
 
         readQuotas.MaxFileSize = 500;
-        REQUIRE_THROWS_MATCHES(fx::gltf::LoadFromBinary(glbFile, readQuotas), fx::gltf::invalid_gltf_document, ExceptionContainsMatcher("MaxFileSize"));
+        REQUIRE_THROWS_MATCHES(fx::gltf::LoadFromBinary(glbFile, readQuotas), fx::gltf::invalid_gltf_document, ExceptionContainsMatcher("MaxFileSize", true));
 
         readQuotas = {};
         readQuotas.MaxBufferCount = 1;
@@ -156,7 +156,7 @@ TEST_CASE("exceptions")
     SECTION("load : mismatched")
     {
         REQUIRE_THROWS_MATCHES(fx::gltf::LoadFromText("data/glTF-Sample-Models/2.0/Box/glTF-Binary/Box.glb"), fx::gltf::invalid_gltf_document, ExceptionContainsMatcher("json.exception", true));
-        REQUIRE_THROWS_MATCHES(fx::gltf::LoadFromBinary("data/glTF-Sample-Models/2.0/Box/glTF/Box.gltf"), fx::gltf::invalid_gltf_document, ExceptionContainsMatcher("GLB header"));
+        REQUIRE_THROWS_MATCHES(fx::gltf::LoadFromBinary("data/glTF-Sample-Models/2.0/Box/glTF/Box.gltf"), fx::gltf::invalid_gltf_document, ExceptionContainsMatcher("GLB header", true));
     }
 
     SECTION("load / save : invalid path")

--- a/test/src/unit-exceptions.cpp
+++ b/test/src/unit-exceptions.cpp
@@ -144,7 +144,7 @@ TEST_CASE("exceptions")
         REQUIRE_THROWS_MATCHES(fx::gltf::LoadFromText(externalFile, readQuotas), fx::gltf::invalid_gltf_document, ExceptionContainsMatcher("MaxBufferByteLength", true));
 
         readQuotas.MaxFileSize = 500;
-        REQUIRE_THROWS_MATCHES(fx::gltf::LoadFromBinary(glbFile, readQuotas), fx::gltf::invalid_gltf_document, ExceptionContainsMatcher("MaxFileSize", true));
+        REQUIRE_THROWS_MATCHES(fx::gltf::LoadFromBinary(glbFile, readQuotas), fx::gltf::invalid_gltf_document, ExceptionContainsMatcher("MaxFileSize"));
 
         readQuotas = {};
         readQuotas.MaxBufferCount = 1;
@@ -156,7 +156,7 @@ TEST_CASE("exceptions")
     SECTION("load : mismatched")
     {
         REQUIRE_THROWS_MATCHES(fx::gltf::LoadFromText("data/glTF-Sample-Models/2.0/Box/glTF-Binary/Box.glb"), fx::gltf::invalid_gltf_document, ExceptionContainsMatcher("json.exception", true));
-        REQUIRE_THROWS_MATCHES(fx::gltf::LoadFromBinary("data/glTF-Sample-Models/2.0/Box/glTF/Box.gltf"), fx::gltf::invalid_gltf_document, ExceptionContainsMatcher("GLB header", true));
+        REQUIRE_THROWS_MATCHES(fx::gltf::LoadFromBinary("data/glTF-Sample-Models/2.0/Box/glTF/Box.gltf"), fx::gltf::invalid_gltf_document, ExceptionContainsMatcher("GLB header"));
     }
 
     SECTION("load / save : invalid path")


### PR DESCRIPTION
The reasons for this are outlined in #59 