### PR TITLE
Use cpp17 fs::u8path on windows if available

### DIFF
--- a/include/fx/gltf.h
+++ b/include/fx/gltf.h
@@ -21,6 +21,18 @@
 #if (defined(__cplusplus) && __cplusplus >= 201703L) || (defined(_MSVC_LANG) && (_MSVC_LANG >= 201703L) && (_MSC_VER >= 1911))
 #define FX_GLTF_HAS_CPP_17
 #include <string_view>
+
+#ifdef _MSC_VER
+#if __has_include(<filesystem>)
+#define FX_GLTF_HAS_STD_FILESYSTEM
+#include <filesystem>
+#define FX_GLTF_UTF8_PATH(x) std::filesystem::u8path(x)
+#endif
+#endif
+#endif
+
+#ifndef FX_GLTF_UTF8_PATH
+#define FX_GLTF_UTF8_PATH
 #endif
 
 namespace fx
@@ -1659,7 +1671,7 @@ namespace gltf
                     }
                     else
                     {
-                        std::ifstream fileData(detail::CreateBufferUriPath(dataContext.bufferRootPath, buffer.uri), std::ios::binary);
+                        std::ifstream fileData(FX_GLTF_UTF8_PATH(detail::CreateBufferUriPath(dataContext.bufferRootPath, buffer.uri)), std::ios::binary);
                         if (!fileData.good())
                         {
                             throw invalid_gltf_document("Invalid buffer.uri value", buffer.uri);
@@ -1771,7 +1783,7 @@ namespace gltf
                 Buffer const & buffer = document.buffers[externalBufferIndex];
                 if (!buffer.IsEmbeddedResource())
                 {
-                    std::ofstream fileData(detail::CreateBufferUriPath(documentRootPath, buffer.uri), std::ios::binary);
+                    std::ofstream fileData(FX_GLTF_UTF8_PATH(detail::CreateBufferUriPath(documentRootPath, buffer.uri)), std::ios::binary);
                     if (!fileData.good())
                     {
                         throw invalid_gltf_document("Invalid buffer.uri value", buffer.uri);
@@ -1810,7 +1822,7 @@ namespace gltf
 
     inline Document LoadFromText(std::string const & documentFilePath, ReadQuotas const & readQuotas = {})
     {
-        std::ifstream input(documentFilePath);
+        std::ifstream input(FX_GLTF_UTF8_PATH(documentFilePath));
         if (!input.is_open())
         {
             throw std::system_error(std::make_error_code(std::errc::no_such_file_or_directory));
@@ -1879,7 +1891,7 @@ namespace gltf
 
     inline Document LoadFromBinary(std::string const & documentFilePath, ReadQuotas const & readQuotas = {})
     {
-        std::ifstream input(documentFilePath, std::ios::binary);
+        std::ifstream input(FX_GLTF_UTF8_PATH(documentFilePath), std::ios::binary);
         if (!input.is_open())
         {
             throw std::system_error(std::make_error_code(std::errc::no_such_file_or_directory));
@@ -1912,7 +1924,7 @@ namespace gltf
 
     inline void Save(Document const & document, std::string const & documentFilePath, bool useBinaryFormat)
     {
-        std::ofstream output(documentFilePath, useBinaryFormat ? std::ios::binary : std::ios::out);
+        std::ofstream output(FX_GLTF_UTF8_PATH(documentFilePath), useBinaryFormat ? std::ios::binary : std::ios::out);
         Save(document, output, detail::GetDocumentRootPath(documentFilePath), useBinaryFormat);
     }
 } // namespace gltf

--- a/test/data/Unicde-Path-岩瀬竜也/Box.gltf
+++ b/test/data/Unicde-Path-岩瀬竜也/Box.gltf
@@ -1,0 +1,142 @@
+{
+    "asset": {
+        "generator": "COLLADA2GLTF",
+        "version": "2.0"
+    },
+    "scene": 0,
+    "scenes": [
+        {
+            "nodes": [
+                0
+            ]
+        }
+    ],
+    "nodes": [
+        {
+            "children": [
+                1
+            ],
+            "matrix": [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                -1.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0
+            ]
+        },
+        {
+            "mesh": 0
+        }
+    ],
+    "meshes": [
+        {
+            "primitives": [
+                {
+                    "attributes": {
+                        "NORMAL": 1,
+                        "POSITION": 2
+                    },
+                    "indices": 0,
+                    "mode": 4,
+                    "material": 0
+                }
+            ],
+            "name": "Mesh"
+        }
+    ],
+    "accessors": [
+        {
+            "bufferView": 0,
+            "byteOffset": 0,
+            "componentType": 5123,
+            "count": 36,
+            "max": [
+                23
+            ],
+            "min": [
+                0
+            ],
+            "type": "SCALAR"
+        },
+        {
+            "bufferView": 1,
+            "byteOffset": 0,
+            "componentType": 5126,
+            "count": 24,
+            "max": [
+                1.0,
+                1.0,
+                1.0
+            ],
+            "min": [
+                -1.0,
+                -1.0,
+                -1.0
+            ],
+            "type": "VEC3"
+        },
+        {
+            "bufferView": 1,
+            "byteOffset": 288,
+            "componentType": 5126,
+            "count": 24,
+            "max": [
+                0.5,
+                0.5,
+                0.5
+            ],
+            "min": [
+                -0.5,
+                -0.5,
+                -0.5
+            ],
+            "type": "VEC3"
+        }
+    ],
+    "materials": [
+        {
+            "pbrMetallicRoughness": {
+                "baseColorFactor": [
+                    0.800000011920929,
+                    0.0,
+                    0.0,
+                    1.0
+                ],
+                "metallicFactor": 0.0
+            },
+            "name": "Red"
+        }
+    ],
+    "bufferViews": [
+        {
+            "buffer": 0,
+            "byteOffset": 576,
+            "byteLength": 72,
+            "target": 34963
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 0,
+            "byteLength": 576,
+            "byteStride": 12,
+            "target": 34962
+        }
+    ],
+    "buffers": [
+        {
+            "byteLength": 648,
+            "uri": "data:application/octet-stream;base64,AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAvwAAAL8AAAA/AAAAPwAAAL8AAAA/AAAAvwAAAD8AAAA/AAAAPwAAAD8AAAA/AAAAPwAAAL8AAAA/AAAAvwAAAL8AAAA/AAAAPwAAAL8AAAC/AAAAvwAAAL8AAAC/AAAAPwAAAD8AAAA/AAAAPwAAAL8AAAA/AAAAPwAAAD8AAAC/AAAAPwAAAL8AAAC/AAAAvwAAAD8AAAA/AAAAPwAAAD8AAAA/AAAAvwAAAD8AAAC/AAAAPwAAAD8AAAC/AAAAvwAAAL8AAAA/AAAAvwAAAD8AAAA/AAAAvwAAAL8AAAC/AAAAvwAAAD8AAAC/AAAAvwAAAL8AAAC/AAAAvwAAAD8AAAC/AAAAPwAAAL8AAAC/AAAAPwAAAD8AAAC/AAABAAIAAwACAAEABAAFAAYABwAGAAUACAAJAAoACwAKAAkADAANAA4ADwAOAA0AEAARABIAEwASABEAFAAVABYAFwAWABUA"
+        }
+    ]
+}

--- a/test/src/unit-saveload.cpp
+++ b/test/src/unit-saveload.cpp
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------
+﻿// ------------------------------------------------------------
 // Copyright(c) 2019 Jesse Yurkovich
 // Licensed under the MIT License <http://opensource.org/licenses/MIT>.
 // See the LICENSE file in the repo root for full license information.
@@ -204,6 +204,24 @@ TEST_CASE("saveload")
         REQUIRE(copy1.buffers.front().data == originalDocument1.buffers.front().data);
         REQUIRE(copy2.buffers.front().data == originalDocument2.buffers.front().data);
     }
+
+#ifdef FX_GLTF_HAS_STD_FILESYSTEM
+    SECTION("load embedded from unicode path - save binary with unicode name")
+    {
+        std::string originalFile{ u8"data/Unicde-Path-岩瀬竜也/Box.gltf" };
+        std::string newFile{ utility::GetTestOutputDir() + u8"/Unicde-Name-岩瀬竜也.glb" };
+
+        fx::gltf::Document originalDocument = fx::gltf::LoadFromText(originalFile);
+
+        originalDocument.buffers.front().uri.clear();
+        fx::gltf::Save(originalDocument, newFile, true);
+
+        fx::gltf::Document newDocument = fx::gltf::LoadFromBinary(newFile);
+
+        REQUIRE(newDocument.buffers.front().data == originalDocument.buffers.front().data);
+        REQUIRE(newDocument.buffers.front().uri.empty());
+    }
+#endif
 
     utility::CleanupTestOutputDir();
 }


### PR DESCRIPTION
I had trouble loading model from unicode filepath. Unfortunately string argument to ifstream/ofstream is not treated as utf8 on Windows by default. It requires switching global locale to achieve that, which is not always possible. So we can use filepath overload of i/ofstream from C++17 to get same behavior as on other systems.