### PR TITLE
Simplify viewer command line attaching

### DIFF
--- a/examples/viewer/viewer.cpp
+++ b/examples/viewer/viewer.cpp
@@ -64,7 +64,7 @@ public:
 
         ShowWindow(hwnd, nCmdShow);
 
-        // Main sample loop.
+        // Main loop.
         MSG msg{};
         while (msg.message != WM_QUIT)
         {
@@ -210,43 +210,19 @@ private:
     }
 };
 
-int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR, _In_ int nCmdShow)
+int wmain()
 {
-    FILE * attachedOut{};
-    FILE * attachedIn{};
-    if (AllocConsole() == TRUE)
-    {
-        freopen_s(&attachedOut, "CONOUT$", "w", stdout);
-        freopen_s(&attachedIn, "CONIN$", "r", stdin);
-    }
-
     int result = -1;
     try
     {
         COMUtil::Init();
-        result = Win32Application::Run(hInstance, nCmdShow);
+        result = Win32Application::Run(GetModuleHandle(nullptr), SW_SHOWDEFAULT);
     }
     catch (std::exception const & e)
     {
         std::string message;
         fx::FormatException(message, e);
         std::cout << message << std::endl;
-    }
-
-    if (result < 0)
-    {
-        std::cout << "Press [ENTER] to continue" << std::endl;
-        std::cin.get();
-    }
-
-    if (attachedOut != nullptr)
-    {
-        fclose(attachedOut);
-    }
-
-    if (attachedIn != nullptr)
-    {
-        fclose(attachedIn);
     }
 
     return result;

--- a/examples/viewer/viewer.vcxproj
+++ b/examples/viewer/viewer.vcxproj
@@ -70,7 +70,7 @@
       <EnablePREfast>false</EnablePREfast>
     </ClCompile>
     <Link>
-      <SubSystem>Windows</SubSystem>
+      <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>d3d12.lib;d3dcompiler.lib;dxgi.lib;dxguid.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>d3d12.dll</DelayLoadDLLs>
@@ -91,7 +91,7 @@
       <EnablePREfast>false</EnablePREfast>
     </ClCompile>
     <Link>
-      <SubSystem>Windows</SubSystem>
+      <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>


### PR DESCRIPTION
There really wasn't a great benefit to starting off as a non-console app and attaching to the console afterwards.  Just start off as a console and create a window as necessary.