### PR TITLE
Make it easier to disable tests when using fx-gltf with FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required (VERSION 3.8)
 project(fx-gltf VERSION 1.0.2)
 
+option(FX_GLTF_BUILD_TESTS "If the tests should be built" ON)
 option(FX_GLTF_INSTALL "If the library should be installed" ON)
 option(FX_GLTF_USE_INSTALLED_DEPS "If installed or repo local dependencies should be used" OFF)
 
@@ -46,7 +47,7 @@ endif()
 ##
 include(CTest)
 
-if(BUILD_TESTING)
+if(FX_GLTF_BUILD_TESTS AND BUILD_TESTING)
     enable_testing()
     add_subdirectory(test)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,7 @@
 cmake_minimum_required(VERSION 3.8)
 project(fx-gltf VERSION 1.0.2)
 
-if (POLICY CMP0054)
-    cmake_policy(SET CMP0054 NEW)
-endif()
+cmake_policy(SET CMP0054 NEW)
 
 if (POLICY CMP0077)
     cmake_policy(SET CMP0077 NEW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,13 @@
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required(VERSION 3.8)
 project(fx-gltf VERSION 1.0.2)
+
+if (POLICY CMP0054)
+    cmake_policy(SET CMP0054 NEW)
+endif()
+
+if (POLICY CMP0077)
+    cmake_policy(SET CMP0077 NEW)
+endif()
 
 option(FX_GLTF_BUILD_TESTS "If the tests should be built" ON)
 option(FX_GLTF_INSTALL "If the library should be installed" ON)


### PR DESCRIPTION
When depending on `fx-gltf` using [CMake's `FetchContent` module](https://cmake.org/cmake/help/latest/module/FetchContent.html), it is quite common to set an option to disable tests.

For example, this is the recommended way to use GLFW with FetchContent:

```cmake
# FetchContent_Declare(glfw ...)
FetchContent_GetProperties(glfw)
if(NOT glfw_POPULATED)
    FetchContent_Populate(glfw)
    set(GLFW_BUILD_DOCS OFF CACHE BOOL "" FORCE)
    set(GLFW_BUILD_TESTS OFF CACHE BOOL "" FORCE)
    set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
    add_subdirectory(${glfw_SOURCE_DIR} ${glfw_BINARY_DIR})
endif()
```

If I'm not mistaken, there was no such way to disable `fx-gltf` tests. This is what this PR allows:

```cmake
# FetchContent_Declare(fx-gltf ...)
FetchContent_GetProperties(fx-gltf)
if(NOT fx-gltf_POPULATED)
    FetchContent_Populate(fx-gltf)
    set(FX_GLTF_INSTALL OFF CACHE BOOL "" FORCE)
    set(FX_GLTF_BUILD_TESTS OFF CACHE BOOL "" FORCE)
    add_subdirectory(${fx-gltf_SOURCE_DIR} ${fx-gltf_BINARY_DIR})
endif()
```