### PR TITLE
Fix a warning about an enumeration value not being handled in a switch statement

### DIFF
--- a/include/fx/gltf.h
+++ b/include/fx/gltf.h
@@ -1339,6 +1339,8 @@ namespace gltf
             case Accessor::ComponentType::UnsignedInt:
                 WriteMinMaxConvert<uint32_t>(json, accessor);
                 break;
+            case Accessor::ComponentType::None:
+                break;
             }
         }
     } // namespace detail


### PR DESCRIPTION
`Accessor::ComponentType::None` was not explicitly handled by the switch statement in  `fx::gltf::detail::WriteAccessorMinMax(nlohmann::json&, Accessor const&)` (at `include/fx/gltf.h:1318`).

This caused a warning on some compilers with the right flags. Here's an example with GCC 10:

```
/[...]/include/fx/gltf.h:1318:20: warning: enumeration value ‘None’ not handled in switch [-Wswitch]
 1318 |             switch (accessor.componentType)
      |                    ^
```

This PR addresses this by explicitly ignoring the missing value, keeping the old behaviour while silencing the warning.