### PR TITLE
Fix a wrong test on quaternion identity in the viewer app

### DIFF
--- a/examples/viewer/DirectX/D3DGraph.h
+++ b/examples/viewer/DirectX/D3DGraph.h
@@ -42,7 +42,7 @@ namespace Graph
                 graphNode.CurrentTransform = DirectX::XMMatrixScalingFromVector(DirectX::XMLoadFloat3(&local)) * graphNode.CurrentTransform;
             }
 
-            if (node.rotation != fx::gltf::defaults::IdentityVec4)
+            if (node.rotation != fx::gltf::defaults::IdentityRotation)
             {
                 const DirectX::XMFLOAT4 local(node.rotation.data());
                 graphNode.CurrentTransform = DirectX::XMMatrixRotationQuaternion(DirectX::XMLoadFloat4(&local)) * graphNode.CurrentTransform;


### PR DESCRIPTION
Fix a small issue on the node transformation parsing in the gltf structure. 

This modification has no consequence on the viewer app, it just bypasses quaternion to matrix conversion in some cases (except if the quaternion is equal to { 1, 1, 1, 1 } but not sure it can happen)