### PR TITLE
Prevent implicit json conversions

### DIFF
--- a/include/fx/gltf.h
+++ b/include/fx/gltf.h
@@ -1709,7 +1709,7 @@ namespace gltf
 
         inline Document Create(nlohmann::json const & json, DataContext const & dataContext)
         {
-            Document document = json;
+            Document document = json.get<Document>();
 
             if (document.buffers.size() > dataContext.readQuotas.MaxBufferCount)
             {


### PR DESCRIPTION
This simple patch allow the library to be used with `JSON_USE_IMPLICIT_CONVERSIONS=0`